### PR TITLE
Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,8 @@ on:
     push:
         branches:
             - 'main'
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DeWildeDaan/Argo-Trivy-Insights/security/code-scanning/1](https://github.com/DeWildeDaan/Argo-Trivy-Insights/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/build.yaml` at the workflow root, right after the `on:` section and before `jobs:`.  
For this workflow, the minimal safe setting is:

- `contents: read`

This preserves current functionality (checkout/build/package/upload-artifact) while ensuring `GITHUB_TOKEN` is not over-privileged if repository defaults are broad now or in the future.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
