### PR TITLE
Fix/cluster overview dashboard streaming and removing ruplicate resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argo-trivy-insights",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argo-trivy-insights",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "devDependencies": {
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argo-trivy-insights",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Argo CD UI extension showing Trivy insights",
   "scripts": {

--- a/src/AppView.tsx
+++ b/src/AppView.tsx
@@ -24,6 +24,7 @@ import {
   TABS,
 } from './reportKinds';
 import { REPORT_KIND_LABEL } from './trivyReport';
+import { deduplicateReports } from './reportDeduplication';
 import { SbomReportView } from './SbomReportView';
 import { TabBar } from './TabBar';
 import { AppViewProps, ResourceNode } from './types';
@@ -197,11 +198,13 @@ export const AppView: React.FC<AppViewProps> = ({ application, tree }) => {
         setByKind((prev) => {
           const prevState = prev[kind];
           const prevData = prevState.status === 'loading' ? prevState.data : [];
+          const allData = [...prevData, ...items];
+          const dedupData = deduplicateReports(allData);
           return {
             ...prev,
             [kind]: {
               status: 'loading',
-              data: [...prevData, ...items],
+              data: dedupData,
               settled: settledCounts[kind] ?? 0,
               total: targetsByKind[kind]!.length,
             },
@@ -229,6 +232,8 @@ export const AppView: React.FC<AppViewProps> = ({ application, tree }) => {
           setByKind((prev) => {
             const prevState = prev[kind];
             const prevData = prevState.status === 'loading' ? prevState.data : [];
+            const allData = [...prevData, ...remaining];
+            const dedupData = deduplicateReports(allData);
             const failed = failedCounts[kind] ?? 0;
             if (total > 0 && failed === total) {
               return {
@@ -238,7 +243,7 @@ export const AppView: React.FC<AppViewProps> = ({ application, tree }) => {
             }
             return {
               ...prev,
-              [kind]: { status: 'loaded', data: [...prevData, ...remaining], failedCount: failed },
+              [kind]: { status: 'loaded', data: dedupData, failedCount: failed },
             };
           });
         }

--- a/src/OverviewView.tsx
+++ b/src/OverviewView.tsx
@@ -230,14 +230,16 @@ export const OverviewView: React.FC<OverviewViewProps> = ({ byKind, visibleKinds
     [byKind]
   );
 
-  // Blocks the dashboard only until each finding kind has produced *some*
-  // data (or finished with none) - once every kind has started streaming in
-  // results, the dashboard renders and its stats keep updating live as more
-  // arrives, rather than waiting for every kind to fully finish.
-  const isLoading = FINDING_KINDS.some((kind) => {
+  // Blocks the dashboard only until at least one finding kind has produced
+  // data. Once the first batch arrives from any kind, the dashboard renders
+  // immediately and stats update live as more data arrives, rather than
+  // waiting for all kinds to produce initial results.
+  const anyKindHasData = FINDING_KINDS.some((kind) => {
     const state = byKind[kind];
-    return state.status === 'idle' || (state.status === 'loading' && state.data.length === 0);
+    return state.status !== 'idle' && state.status !== 'error' && state.data.length > 0;
   });
+  const anyKindLoading = FINDING_KINDS.some((kind) => byKind[kind].status === 'loading' || byKind[kind].status === 'idle');
+  const isLoading = !anyKindHasData && anyKindLoading;
   const isStillStreaming = REPORT_KINDS.some((kind) => byKind[kind].status === 'loading');
 
   const findingRowsByKind: Partial<Record<ReportKind, Array<{ severity: string }>>> = {

--- a/src/SystemView.tsx
+++ b/src/SystemView.tsx
@@ -24,6 +24,7 @@ import {
   TABS,
 } from './reportKinds';
 import { REPORT_KIND_LABEL, SOURCE_APP_FIELD } from './trivyReport';
+import { deduplicateReports } from './reportDeduplication';
 import { SbomReportView } from './SbomReportView';
 import { TabBar } from './TabBar';
 import { Application, ResourceNode } from './types';
@@ -281,11 +282,13 @@ export const SystemView: React.FC = () => {
         setByKind((prev) => {
           const prevState = prev[kind];
           const prevData = prevState.status === 'loading' ? prevState.data : [];
+          const allData = [...prevData, ...items];
+          const dedupData = deduplicateReports(allData);
           return {
             ...prev,
             [kind]: {
               status: 'loading',
-              data: [...prevData, ...items],
+              data: dedupData,
               settled: settledCounts[kind] ?? 0,
               total: targetsByKind[kind]!.length,
             },
@@ -313,6 +316,8 @@ export const SystemView: React.FC = () => {
           setByKind((prev) => {
             const prevState = prev[kind];
             const prevData = prevState.status === 'loading' ? prevState.data : [];
+            const allData = [...prevData, ...remaining];
+            const dedupData = deduplicateReports(allData);
             const failed = failedCounts[kind] ?? 0;
             if (total > 0 && failed === total) {
               return {
@@ -322,7 +327,7 @@ export const SystemView: React.FC = () => {
             }
             return {
               ...prev,
-              [kind]: { status: 'loaded', data: [...prevData, ...remaining], failedCount: failed },
+              [kind]: { status: 'loaded', data: dedupData, failedCount: failed },
             };
           });
         }

--- a/src/SystemView.tsx
+++ b/src/SystemView.tsx
@@ -347,7 +347,7 @@ export const SystemView: React.FC = () => {
     invalidateApiCache();
     lastFetchKeyRef.current = {};
     setAppsRetryTick((tick) => tick + 1);
-    setRetryTick((tick) => tick + 1);
+    setTreesRetryTick((tick) => tick + 1);
   }, []);
 
   const state = activeTab === 'Overview' ? undefined : (byKind as Record<ReportTab, FetchState>)[activeTab];

--- a/src/reportDeduplication.ts
+++ b/src/reportDeduplication.ts
@@ -1,0 +1,37 @@
+/**
+ * Extracts the composite key that uniquely identifies which resource a report CRD belongs to.
+ * Multiple CRDs with the same key are duplicate scans of the same resource.
+ */
+function reportResourceKey(report: any): string {
+  const labels = report?.metadata?.labels ?? {};
+  const resourceName = labels['trivy-operator.resource.name'];
+  const resourceKind = labels['trivy-operator.resource.kind'];
+  const containerName = labels['trivy-operator.container.name'];
+  const namespace = report?.metadata?.namespace;
+
+  // Composite key: namespace/kind/name/container
+  // Empty fields are preserved to maintain uniqueness
+  return `${namespace ?? ''}/${resourceKind ?? ''}/${resourceName ?? ''}/${containerName ?? ''}`;
+}
+
+/**
+ * Deduplicates an array of report CRDs, keeping only the latest (by creationTimestamp) for each resource.
+ * This filters out stale scans that remain in the cluster after deployments are updated.
+ */
+export function deduplicateReports(reports: unknown[]): unknown[] {
+  const latestByKey = new Map<string, { report: unknown; timestamp: number }>();
+
+  for (const report of reports) {
+    const key = reportResourceKey(report);
+    // Parse creationTimestamp to get milliseconds since epoch
+    const createdAt = new Date((report as any)?.metadata?.creationTimestamp ?? 0).getTime();
+
+    const current = latestByKey.get(key);
+    // Keep the report with the later timestamp (handle NaN gracefully)
+    if (!current || (createdAt > 0 && createdAt > current.timestamp)) {
+      latestByKey.set(key, { report, timestamp: createdAt });
+    }
+  }
+
+  return Array.from(latestByKey.values()).map(({ report }) => report);
+}


### PR DESCRIPTION
## Description
Cluster overview dashboard no longes has a loading screen untill all resources are loaded but streams the results and updates the dashboard as the data comes in providing a shorter waiting experience. 

Also removed duplicate results from stale trivy CRDs.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build/CI

## Testing
- [x] Tested locally with dev install (`npm run install:dev`)
- [x] All checks pass (`npm run typecheck`, `npm run build`)
